### PR TITLE
(Sprint 2) Limites de recursos y reglas de seguridad para el deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -13,11 +13,22 @@ spec:
       labels:
         app: python-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+  
       containers:
         - name: python-app
           image: scptx0/python-app:1.1
           ports:
             - containerPort: 5000
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
 
           resources:
             requests:


### PR DESCRIPTION
## Cambios realizados

- Se agregaron los límites para el deployment `python-app`. Como mínimo se puede usar `128Mi` de memoria y `100m` de CPU, mientras que, como maximo se puede usar `256Mi` de memoria y `200m` de CPU.
- Se agregaron las reglas de seguridad que se pidieron:
  - `runAsNonRoot` y `runAsUser` a nivel de pod (aplicado a todos los contenedores)
  - `readOnlyRootFilesystem`, `allowPrivilegeEscalation`, `capabilities.drop: ALL` a nivel de contenedor
 
## Issues relacionados

- #8